### PR TITLE
#163346061 modify signup endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3291,6 +3291,11 @@
                 "tweetnacl": "0.14.5"
             }
         },
+        "bcryptjs": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+            "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+        },
         "binary-extensions": {
             "version": "1.12.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
+    "bcryptjs": "^2.4.3",
     "cookie-parser": "~1.4.3",
     "cors": "^2.8.5",
     "debug": "~2.6.9",

--- a/server/app.js
+++ b/server/app.js
@@ -5,7 +5,6 @@ import cors from 'cors';
 
 import createError from './helpers/createError';
 import routes from './routes/indexRouter';
-import authenticator from './middleware/authenticator';
 
 const app = express();
 
@@ -17,8 +16,8 @@ app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-app.use('/api/v1', (req, res, next) => {
-  if (req.path === '/') {
+app.use('/', (req, res, next) => {
+  if (req.path === '/' || /^\/api\/v\d+\/*$/.test(req.path)) {
     res.status(200).json({
       status: 200,
       message: 'welcome to questioner, please refer to our API docs for valid requests',
@@ -26,17 +25,9 @@ app.use('/api/v1', (req, res, next) => {
   } else next();
 });
 
-app.use('/api/v1/auth', routes.userRoute);
-app.use('/api/v1', [authenticator.verify, routes.generalRoute]);
+app.use('/api/v1', routes.userRoute, routes.generalRoute);
 
 app.use('/:invalid', (req, res) => createError(400, res, 'request path invalid, please refer to API documentation'));
-
-app.use('/', (req, res) => {
-  res.status(200).json({
-    status: 200,
-    message: 'welcome to questioner, please refer to our API docs for valid requests',
-  });
-});
 
 // error handler
 app.use((err, req, res, next) => {

--- a/server/app.js
+++ b/server/app.js
@@ -15,7 +15,6 @@ app.use(cors());
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-
 app.use('/', (req, res, next) => {
   if (req.path === '/' || /^\/api\/v\d+\/*$/.test(req.path)) {
     res.status(200).json({
@@ -24,9 +23,7 @@ app.use('/', (req, res, next) => {
     });
   } else next();
 });
-
 app.use('/api/v1', routes.userRoute, routes.generalRoute);
-
 app.use('/:invalid', (req, res) => createError(400, res, 'request path invalid, please refer to API documentation'));
 
 // error handler

--- a/server/controllers/comments.js
+++ b/server/controllers/comments.js
@@ -28,12 +28,8 @@ const control = {
       if (rowCount > 0) res.status(201).json(success(201, rows));
       else next(500);
     } catch (error) {
-      if (error.code === '23503') {
-        res.status(200).json({
-          status: 200,
-          message: 'either the user or question does not exist',
-        });
-      } else if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
+      if (error.code === '23503') createError(404, res, 'the question you are trying to comment on was not found');
+      else if (error.details[0]) createError(422, res, error.details[0].message.replace(/"/g, ''));
       else createError(500, res);
     }
   },

--- a/server/controllers/meetups.js
+++ b/server/controllers/meetups.js
@@ -56,7 +56,7 @@ const control = {
         if (rowCount > 0) res.status(201).json(success(201, rows));
         else next(500);
       } catch (error) {
-        if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
+        if (error.details[0]) createError(422, res, error.details[0].message.replace(/"/g, ''));
         else createError(500, res);
       }
     } else createError(403, res, 'only users with administrative rights can create meetups');
@@ -76,7 +76,7 @@ const control = {
           createError(404, res, 'meetup not found, it has either been deleted or it never existed');
         }
       } catch (error) {
-        if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
+        if (error.details[0]) createError(422, res, error.details[0].message.replace(/"/g, ''));
         else createError(500, res);
       }
     } else createError(403, res, 'only users with administrative rights can delete meetups');
@@ -89,9 +89,9 @@ const control = {
         const body = await validator(req.body, 'updateMeetup');
         const { rows, rowCount } = await meetupQuery.update(body, meetupId);
         if (rowCount > 0) res.status(200).json(success(200, rows));
-        else createError(404, res, 'meet does not exist');
+        else createError(404, res, 'meetup does not exist');
       } catch (error) {
-        if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
+        if (error.details[0]) createError(422, res, error.details[0].message.replace(/"/g, ''));
         else createError(500, res);
       }
     } else createError(403, res, 'only users with administrative rights can update meetups');

--- a/server/controllers/notifications.js
+++ b/server/controllers/notifications.js
@@ -79,8 +79,7 @@ const control = {
         });
       }
     } catch (error) {
-      if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
-      else createError(500, res);
+      createError(500, res);
     }
   },
 };

--- a/server/controllers/notifications.js
+++ b/server/controllers/notifications.js
@@ -17,8 +17,8 @@ const control = {
       }
     } catch (error) {
       if (error.code === '23503') {
-        res.status(201).json({
-          status: 201,
+        res.status(200).json({
+          status: 200,
           message: 'you have already set up notifications for this meetup',
         });
       } else if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
@@ -35,13 +35,9 @@ const control = {
           status: 200,
           message: `notification reset for meetup ${meetupId}`,
         });
-      } else {
-        res.status(200).json({
-          status: 200,
-          message: `you have not registered notifications for meetup ${meetupId}`,
-        });
-      }
+      } else createError(404, res, 'meetup not registered for notifications or meetup does not exist');
     } catch (error) {
+      console.log(error)
       if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
       else createError(500, res);
     }
@@ -56,12 +52,7 @@ const control = {
           status: 200,
           message: `notification stopped for ${meetupId}`,
         });
-      } else {
-        res.status(200).json({
-          status: 200,
-          message: `you have not registered notifications for meetup ${meetupId}`,
-        });
-      }
+      } else createError(404, res, 'meetup not registered for notifications or meetup does not exist');
     } catch (error) {
       if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
       else createError(500, res);

--- a/server/controllers/questions.js
+++ b/server/controllers/questions.js
@@ -37,7 +37,7 @@ const control = {
       else next(500);
     } catch (error) {
       if (error.code === '23503') createError(404, res, 'either the user or meetup does not exist');
-      else if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
+      else if (error.details[0]) createError(422, res, error.details[0].message.replace(/"/g, ''));
       else createError(500, res);
     }
   },

--- a/server/controllers/rsvps.js
+++ b/server/controllers/rsvps.js
@@ -16,10 +16,10 @@ const control = {
         else next(500);
       } catch (error) {
         if (error.code === '23503') createError(404, res, 'meetup does not exist');
-        else if (error.details[0]) createError(400, res, error.details[0].message.replace(/[[\]"]/g, ''));
+        else if (error.details[0]) createError(422, res, error.details[0].message.replace(/[[\]"]/g, ''));
         else createError(500, res);
       }
-    } else createError(403, res, 'this route is only available to users');
+    } else createError(403, res, 'you must be a user to rsvp for a meetup');
   },
 };
 

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -26,10 +26,10 @@ const controller = {
       if (error.code === '23505') {
         res.status(200).json({
           status: 200,
-          createError: 'user is already registered',
+          message: 'user is already registered',
         });
-      } else if (error.details[0].type === 'string.regex.base') createError(400, res, 'password must contain 6 - 12 characters');
-      else if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
+      } else if (error.details[0].type === 'string.regex.base') createError(422, res, 'password must contain 6 - 12 characters');
+      else if (error.details[0]) createError(422, res, error.details[0].message.replace(/"/g, ''));
       else createError(500, res);
     }
   },
@@ -45,10 +45,15 @@ const controller = {
           status: 200,
           data: [{ token, user }],
         });
-      } else createError(404, res, 'email or password incorrect');
+        return;
+      }
+      res.status(200).json({
+        status: 200,
+        message: 'email or password incorrect',
+      });
     } catch (error) {
       if (error.routine) createError(403, res);
-      else if (error.details[0].type === 'string.regex.base') createError(400, res, 'password must contain 6 - 12 characters');
+      else if (error.details[0].type === 'string.regex.base') createError(422, res, 'password must contain 6 - 12 characters');
       else createError(400, res, error.details[0].message.replace(/"/g, ''));
     }
   },
@@ -63,9 +68,9 @@ const controller = {
       if (error.code === '23505') {
         res.status(200).json({
           status: 200,
-          createError: 'email already in use',
+          message: 'email already in use',
         });
-      } else if (error.details[0]) createError(400, res, error.details[0].message.replace(/"/g, ''));
+      } else if (error.details[0]) createError(422, res, error.details[0].message.replace(/"/g, ''));
       else createError(500, res);
     }
   },

--- a/server/db/databaseSQL.js
+++ b/server/db/databaseSQL.js
@@ -12,7 +12,7 @@ CREATE TYPE public.votes AS ENUM (
     '1',
     'null'
 );
-CREATE FUNCTION public.all_meets_admin(userid integer) RETURNS TABLE(id integer, happening numeric, topic character varying, location character varying, tags jsonb, images jsonb, rsvp jsonb, questions bigint)
+CREATE FUNCTION public.all_meets_admin(userid integer) RETURNS TABLE(id integer, happening timestamptz, topic character varying, location character varying, tags jsonb, images jsonb, rsvp jsonb, questions bigint)
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -21,7 +21,7 @@ BEGIN
 	LEFT JOIN public.questions q ON q.meetup = m.id
 	GROUP BY (q.meetup, m.id);
 END; $$;
-CREATE FUNCTION public.all_meets_user(userid integer) RETURNS TABLE(id integer, happening numeric, topic character varying, location character varying, tags jsonb, images jsonb, rsvp character varying, questions bigint)
+CREATE FUNCTION public.all_meets_user(userid integer) RETURNS TABLE(id integer, happening timestamptz, topic character varying, location character varying, tags jsonb, images jsonb, rsvp character varying, questions bigint)
     LANGUAGE plpgsql
     AS $$
 BEGIN

--- a/server/db/querydata.js
+++ b/server/db/querydata.js
@@ -2,14 +2,14 @@ import querydb from './querydb';
 import queryGenerator from './querygenerator';
 
 const userQuery = {
-  fields: 'id, firstname, lastname, othername, email, phoneNumber, username, registered, isadmin',
+  fields: 'id, firstname, lastname, othername, email, phoneNumber, username, registered, isadmin, password',
 
   createNew: (body) => {
     const { key1, key2, values } = queryGenerator.insertFields(body);
     return querydb.query(`INSERT INTO public.user (${key1}) VALUES (${key2}) RETURNING ${userQuery.fields}`, values);
   },
 
-  getUser: (email, password) => querydb.query(`SELECT ${userQuery.fields} FROM public.user WHERE email = $1 AND password = $2`, [email, password]),
+  getUser: email => querydb.query(`SELECT ${userQuery.fields} FROM public.user WHERE email = $1`, [email]),
 
   update: (userId, body) => {
     const { key1, key2, values } = queryGenerator.updateFields(body);

--- a/server/db/querydata.js
+++ b/server/db/querydata.js
@@ -22,7 +22,7 @@ const meetupQuery = {
 
   getAll: (userId, isadmin) => querydb.query(`SELECT * from all_meets_${isadmin ? 'admin' : 'user'}(${userId})`),
 
-  getUpcoming: (userId, isadmin) => querydb.query(`SELECT * FROM all_meets_${isadmin ? 'admin' : 'user'}(${userId}) WHERE happening > ${Date.now() - 172800000}`),
+  getUpcoming: (userId, isadmin) => querydb.query(`SELECT * FROM all_meets_${isadmin ? 'admin' : 'user'}(${userId}) WHERE happening > '${new Date().toISOString()}'::timestamptz`),
 
   getSpecific: (userId, isadmin, meetupId) => querydb.query(`SELECT * FROM all_meets_${isadmin ? 'admin' : 'user'}(${userId}) WHERE id = $1`, [meetupId]),
 

--- a/server/db/querydata.js
+++ b/server/db/querydata.js
@@ -74,7 +74,7 @@ const notificationsQuery = {
     [userId, meetupId]),
 
   reset: (userId, meetupId) => querydb.query('UPDATE public.notifications SET last_seen = $1 WHERE meet=$2 AND user_id=$3 RETURNING *;',
-    [Date.now(), meetupId, userId]),
+    [new Date().toISOString(), meetupId, userId]),
 
   clear: (userId, meetupId) => querydb.query('DELETE FROM public.notifications WHERE user_id = $1 AND meet=$2 RETURNING *',
     [userId, meetupId]),

--- a/server/helpers/crypt.js
+++ b/server/helpers/crypt.js
@@ -1,0 +1,22 @@
+import bcrypt from 'bcryptjs';
+
+const crypt = {
+  hash: body => new Promise(async (res) => {
+    const body1 = body;
+    body1.password = await bcrypt.hash(body1.password, 10);
+    res(body1);
+  }),
+
+  verify: (body, password) => new Promise(async (res) => {
+    if (!body) return res(false);
+    const body1 = body;
+    const check = await bcrypt.compare(password, body.password);
+    if (check) {
+      delete body1.password;
+      return res(body1);
+    }
+    return res(false);
+  }),
+};
+
+export default crypt;

--- a/server/helpers/validator.js
+++ b/server/helpers/validator.js
@@ -3,12 +3,12 @@ import joi from 'joi';
 
 const schemas = {
   user: joi.object().keys({
-    firstname: joi.string().alphanum().min(1).required(),
-    lastname: joi.string().alphanum().min(1).required(),
-    othername: joi.string().alphanum().min(1).required(),
+    firstname: joi.string().alphanum().min(1),
+    lastname: joi.string().alphanum().min(1),
+    othername: joi.string().alphanum().min(1),
     email: joi.string().email().required(),
-    phonenumber: joi.string().regex(/^\d+$/).min(6).max(15).required(),
-    username: joi.string().alphanum().min(3).max(10).required(),
+    phonenumber: joi.string().regex(/^\d+$/).min(6).max(15),
+    username: joi.string().alphanum().min(3).max(10),
     password: joi.string().trim().regex(/^[a-zA-Z0-9]{6,12}$/).required(),
   }),
 
@@ -28,7 +28,7 @@ const schemas = {
   }),
 
   meetup: joi.object().keys({
-    happening: joi.number().integer().min(Date.now()).required(),
+    happening: joi.date().iso().min('now').required(),
     location: joi.string().replace(/^ *$/g, '').concat(joi.string().trim().required()),
     topic: joi.string().replace(/^ *$/g, '').concat(joi.string().trim().required()),
     images: joi.array().items(joi.string().required()).required(),

--- a/server/middleware/authenticator.js
+++ b/server/middleware/authenticator.js
@@ -13,9 +13,20 @@ const authenticator = {
   }),
 
   verify: (req, res, next) => {
-    jwt.verify(req.get('auth'), process.env.secretkey, (err, decoded) => {
-      if (err) {
-        createError(403, res, err.message);
+    jwt.verify(req.get('x-access-token'), process.env.secretkey, ({ name, message }, decoded) => {
+      if (name) {
+        let msg;
+        switch (name) {
+          case 'TokenExpiredError':
+            msg = 'your access token is expired, login or signup to get a new one';
+            break;
+          case 'JsonWebTokenError':
+            msg = 'an access token is required to access this resource';
+            break;
+          default:
+            msg = message;
+        }
+        createError(403, res, msg);
         return;
       }
       req.decoded = decoded;

--- a/server/middleware/authenticator.js
+++ b/server/middleware/authenticator.js
@@ -13,8 +13,9 @@ const authenticator = {
   }),
 
   verify: (req, res, next) => {
-    jwt.verify(req.get('x-access-token'), process.env.secretkey, ({ name, message }, decoded) => {
-      if (name) {
+    jwt.verify(req.get('x-access-token'), process.env.secretkey, (error, decoded) => {
+      if (error) {
+        const { name, message } = error;
         let msg;
         switch (name) {
           case 'TokenExpiredError':
@@ -26,7 +27,7 @@ const authenticator = {
           default:
             msg = message;
         }
-        createError(403, res, msg);
+        createError(401, res, msg);
         return;
       }
       req.decoded = decoded;

--- a/server/routes/general.js
+++ b/server/routes/general.js
@@ -1,4 +1,5 @@
 import Router from 'express';
+import authenticator from '../middleware/authenticator';
 import users from '../controllers/users';
 import meetups from '../controllers/meetups';
 import questions from '../controllers/questions';
@@ -8,7 +9,7 @@ import notifications from '../controllers/notifications';
 
 
 const router = Router();
-
+const check = authenticator.verify;
 const methods = ['POST', 'GET', 'PATCH', 'DELETE'];
 
 router.use('/', (req, res, next) => {
@@ -16,38 +17,38 @@ router.use('/', (req, res, next) => {
   else next();
 });
 
-router.get('/meetups/upcoming', meetups.getUpcoming);
+router.get('/meetups/upcoming', check, meetups.getUpcoming);
 
-router.get('/meetups/:meetupId', meetups.getSpecific);
+router.get('/meetups/:meetupId', check, meetups.getSpecific);
 
-router.get('/meetups', meetups.getAll);
+router.get('/meetups', check, meetups.getAll);
 
-router.get('/questions/:meetupId', questions.getAll);
+router.get('/questions/:meetupId', check, questions.getAll);
 
-router.get('/comments/:questionId', comments.getAll);
+router.get('/comments/:questionId', check, comments.getAll);
 
-router.get('/notifications', notifications.getAll);
+router.get('/notifications', check, notifications.getAll);
 
-router.post('/meetups', meetups.createNew);
+router.post('/meetups', check, meetups.createNew);
 
-router.post('/questions', questions.createNew);
+router.post('/questions', check, questions.createNew);
 
-router.post('/comments', comments.createNew);
+router.post('/comments', check, comments.createNew);
 
-router.post('/meetups/:meetupId/rsvps', rsvps.createNew);
+router.post('/meetups/:meetupId/rsvps', check, rsvps.createNew);
 
-router.post('/notifications/:meetupId/register', notifications.register);
+router.post('/notifications/:meetupId/register', check, notifications.register);
 
-router.patch('/users/update', users.update);
+router.patch('/users/update', check, users.update);
 
-router.patch('/meetups/:meetupId', meetups.update);
+router.patch('/meetups/:meetupId', check, meetups.update);
 
-router.patch('/questions/:questionId/:vote', questions.vote);
+router.patch('/questions/:questionId/:vote', check, questions.vote);
 
-router.patch('/notifications/:meetupId/reset', notifications.reset);
+router.patch('/notifications/:meetupId/reset', check, notifications.reset);
 
-router.delete('/meetups/:meetupId', meetups.deleteSpecific);
+router.delete('/meetups/:meetupId', check, meetups.deleteSpecific);
 
-router.delete('/notifications/:meetupId/clear', notifications.clear);
+router.delete('/notifications/:meetupId/clear', check, notifications.clear);
 
 export default router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -3,8 +3,8 @@ import users from '../controllers/users';
 
 const router = Router();
 
-router.post('/login', users.login);
+router.post('/auth/login', users.login);
 
-router.post('/signup', users.signUp);
+router.post('/auth/signup', users.signUp);
 
 export default router;

--- a/spec/a.user.spec.js
+++ b/spec/a.user.spec.js
@@ -75,7 +75,7 @@ describe('user tests', () => {
       });
     });
     it('status 400', () => {
-      expect(data.status).toBe(400);
+      expect(data.status).toBe(422);
     });
     it('an error message', () => {
       expect(data.error).toBeDefined();
@@ -114,7 +114,7 @@ describe('user tests', () => {
         url: url('users/update'),
         json: true,
         headers: {
-          auth: token,
+          'x-access-token': token,
         },
         body: {
           firstname: 'johnny',
@@ -143,7 +143,7 @@ describe('user tests', () => {
         url: url('users/update'),
         json: true,
         headers: {
-          auth: token,
+          'x-access-token': token,
         },
         body: {
           firstname: 5,
@@ -155,8 +155,8 @@ describe('user tests', () => {
           done();
         });
       });
-      it('status 400', () => {
-        expect(data1.status).toBe(400);
+      it('status 422', () => {
+        expect(data1.status).toBe(422);
       });
       it('error message', () => {
         expect(data1.error).toBeDefined();
@@ -181,10 +181,10 @@ describe('user tests', () => {
       });
     });
     it('status 404', () => {
-      expect(data.status).toBe(404);
+      expect(data.status).toBe(200);
     });
     it('error message', () => {
-      expect(data.error).toBeDefined();
+      expect(data.message).toBeDefined();
     });
   });
 
@@ -194,7 +194,7 @@ describe('user tests', () => {
       url: url('auth/login'),
       json: true,
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       body: {
         email: 'john@example.com',
@@ -208,7 +208,7 @@ describe('user tests', () => {
       });
     });
     it('status 400', () => {
-      expect(data.status).toBe(400);
+      expect(data.status).toBe(422);
     });
     it('error message', () => {
       expect(data.error).toBeDefined();

--- a/spec/b.meetups.spec.js
+++ b/spec/b.meetups.spec.js
@@ -21,11 +21,11 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
-        happening: Date.now() + 36000,
+        happening: '2019-03-15T15:30',
         location: 'Abuja',
         topic: 'testing',
         images: ['url1', 'url2'],
@@ -51,11 +51,11 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
-        happening: Date.now() + 36000,
+        happening: '2019-03-15T15:30',
         location: 'Abuja',
         topic: '  ',
         images: ['url1', 'url2'],
@@ -69,7 +69,7 @@ describe('meetup tests', () => {
       });
     });
     it('status 400', () => {
-      expect(data.status).toBe(400);
+      expect(data.status).toBe(422);
     });
     it('an error message', () => {
       expect(data.error).toBeDefined();
@@ -81,7 +81,7 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups/upcoming'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -101,7 +101,7 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups/1'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -124,7 +124,7 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups/8'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -147,7 +147,7 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -173,7 +173,7 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups/1'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -199,7 +199,7 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups/8'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -225,7 +225,7 @@ describe('meetup tests', () => {
     const options = {
       url: url('meetups/1'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -239,7 +239,7 @@ describe('meetup tests', () => {
       });
     });
     it('status 400', () => {
-      expect(data.status).toBe(400);
+      expect(data.status).toBe(422);
     });
     it('an error message', () => {
       expect(data.error).toBeDefined();

--- a/spec/c.questions.spec.js
+++ b/spec/c.questions.spec.js
@@ -21,7 +21,7 @@ describe('question tests', () => {
     const options = {
       url: url('questions'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -48,7 +48,7 @@ describe('question tests', () => {
     const options = {
       url: url('questions'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -63,7 +63,7 @@ describe('question tests', () => {
       });
     });
     it('status 400', () => {
-      expect(data.status).toBe(400);
+      expect(data.status).toBe(422);
     });
     it('an error message', () => {
       expect(data.error).toBeDefined();
@@ -75,7 +75,7 @@ describe('question tests', () => {
     const options = {
       url: url('questions/1'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -98,7 +98,7 @@ describe('question tests', () => {
     const options = {
       url: url('questions/15'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -121,7 +121,7 @@ describe('question tests', () => {
     const options = {
       url: url('questions/1/upvote'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -144,7 +144,7 @@ describe('question tests', () => {
     const options = {
       url: url('questions/1/downvote'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -167,7 +167,7 @@ describe('question tests', () => {
     const options = {
       url: url('questions/1/clear'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -190,7 +190,7 @@ describe('question tests', () => {
     const options = {
       url: url('questions/10/downvote'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -213,7 +213,7 @@ describe('question tests', () => {
     const options = {
       url: url('meetups/8'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };

--- a/spec/d.comments.spec.js
+++ b/spec/d.comments.spec.js
@@ -21,7 +21,7 @@ describe('comments tests', () => {
     const options = {
       url: url('comments'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -48,7 +48,7 @@ describe('comments tests', () => {
     const options = {
       url: url('comments'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -62,8 +62,8 @@ describe('comments tests', () => {
         done();
       });
     });
-    it('status 400', () => {
-      expect(data.status).toBe(400);
+    it('status 422', () => {
+      expect(data.status).toBe(422);
     });
     it('an error message', () => {
       expect(data.error).toBeDefined();
@@ -75,7 +75,7 @@ describe('comments tests', () => {
     const options = {
       url: url('comments'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -90,20 +90,19 @@ describe('comments tests', () => {
       });
     });
     it('status 200', () => {
-      expect(data.status).toBe(200);
+      expect(data.status).toBe(404);
     });
-    it('a freindly message', () => {
-      expect(data.message).toBeDefined();
+    it('a error message', () => {
+      expect(data.error).toBeDefined();
     });
   });
-
 
   describe('get all comments for a specific question', () => {
     let data = {};
     const options = {
       url: url('comments/1'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -126,7 +125,7 @@ describe('comments tests', () => {
     const options = {
       url: url('comments/15'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };

--- a/spec/e.rsvp.spec.js
+++ b/spec/e.rsvp.spec.js
@@ -21,7 +21,7 @@ describe('rsvp tests', () => {
     const options = {
       url: url('meetups/1/rsvps'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -47,7 +47,7 @@ describe('rsvp tests', () => {
     const options = {
       url: url('meetups/1/rsvps'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {
@@ -61,19 +61,19 @@ describe('rsvp tests', () => {
       });
     });
     it('status 400', () => {
-      expect(data.status).toBe(400);
+      expect(data.status).toBe(422);
     });
     it('expects an error message', () => {
       expect(data.error).toBeDefined();
     });
   });
 
-  describe('rsvp for a nonexistent question', () => {
+  describe('rsvp for a nonexistent meetup', () => {
     let data;
     const options = {
       url: url('meetups/8/rsvps'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
       body: {

--- a/spec/f.notifications.spec.js
+++ b/spec/f.notifications.spec.js
@@ -2,6 +2,7 @@
 import jwt from 'jsonwebtoken';
 import Request from 'request';
 import Server from '../server/app';
+import querydb from '../server/db/querydb';
 
 require('dotenv').config();
 
@@ -21,7 +22,7 @@ describe('notification tests', () => {
     const options = {
       url: url('notifications/1/register'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -44,7 +45,7 @@ describe('notification tests', () => {
     const options = {
       url: url('notifications/5/register'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -55,7 +56,7 @@ describe('notification tests', () => {
       });
     });
     it('status 200', () => {
-      expect(data.status).toBe(201);
+      expect(data.status).toBe(200);
     });
     it('a friendly message', () => {
       expect(data.message).toBeDefined();
@@ -67,7 +68,7 @@ describe('notification tests', () => {
     const options = {
       url: url('notifications/1/reset'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -90,7 +91,7 @@ describe('notification tests', () => {
     const options = {
       url: url('notifications/1/reset'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -113,7 +114,7 @@ describe('notification tests', () => {
     const options = {
       url: url('notifications/1/clear'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -136,7 +137,7 @@ describe('notification tests', () => {
     const options = {
       url: url('notifications'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -159,7 +160,7 @@ describe('notification tests', () => {
     const options = {
       url: url('meetups/1'),
       headers: {
-        auth: token,
+        'x-access-token': token,
       },
       json: true,
     };
@@ -175,5 +176,8 @@ describe('notification tests', () => {
     it('a success message', () => {
       expect(data.message).toBeDefined();
     });
+  });
+  afterAll((done) => {
+    querydb.query('DROP SCHEMA public cascade; CREATE SCHEMA public AUTHORIZATION postgres;').then(() => done());
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- update signup endpoint
- change API time format
- update API route protection
- password hashing
#### Description of Task to be completed?
- have signup endpoint only require an email and password for successful account creation
- return all optional fields not provided during registration as null in the returned user object
- change API time format from EPOCH milliseconds to  ISO 8601 time format ```yyyy-mm-ddThh-mm-ssZ```
- remove app wide JWT verification. Only requests with a chance of generating meaningful result should be verified.
- change JWT token header key from ```auth: jwt``` to ```'x-access-token': jwt```
- hashing passwords using the bcryptjs module before storing in database
#### How should this be manually tested?
- test new signup endpoint using postman
- send request  ```POST https://k-questioner.herokuapp.com/api/v1/api/v1/auth/signup``` providing only minimum requirement in the request body
- send request ```GET ttps://k-questioner.herokuapp.com/api/v1/api/v1/meetups``` to view all meetups with the 'happening' field bearing the new time format
#### What are the relevant pivotal tracker stories?
 #163346061
 #163345988
#163346125
#163341471
#163341458
#163151146